### PR TITLE
Enable JSON conversion for non-Flux functions

### DIFF
--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
@@ -66,7 +66,7 @@ public class FluxPojoStreamingConsumerTests {
 
 		@Bean
 		public Consumer<Flux<String>> sinkConsumer(final List<String> sinkCollector) {
-			return foos -> foos.doOnNext(s -> sinkCollector.add(s));
+			return foos -> foos.subscribe(s -> sinkCollector.add(s));
 		}
 	}
 

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxStreamingConsumerTests.java
@@ -52,7 +52,7 @@ public class FluxStreamingConsumerTests {
 
 	@Test
 	public void test() throws Exception {
-		sink.input().send(MessageBuilder.withPayload(new Foo("foo")).build());
+		sink.input().send(MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
 		assertThat(sinkCollector).hasSize(1);
 	}
 

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
@@ -50,7 +50,7 @@ public class PojoStreamingConsumerTests {
 
 	@Test
 	public void test() throws Exception {
-		sink.input().send(MessageBuilder.withPayload(new Foo("foo")).build());
+		sink.input().send(MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
 		assertThat(sinkCollector).hasSize(1);
 	}
 


### PR DESCRIPTION
- use ProxyWrapper consistently around a FluxConsumer as
  well
- Enable introspection for scanned beans
- Fix failing tests by passing JSON string as input messages
  (marshalled form expected from the binder)